### PR TITLE
Optimize Linear

### DIFF
--- a/benchmarks/benchmark_adaptive_avg_pool2d.py
+++ b/benchmarks/benchmark_adaptive_avg_pool2d.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "adaptive avg pool2d forward",
-    "out_sz",
+    ["out_sz"],
     [2**i for i in range(1, 11)],
     {"h": 512, "w": 512},
 )

--- a/benchmarks/benchmark_batch_norm.py
+++ b/benchmarks/benchmark_batch_norm.py
@@ -19,7 +19,7 @@ import util
 import trident
 
 
-@util.report("forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 20})
+@util.report("forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 20})
 def bench_batch_norm_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")
 
@@ -33,7 +33,7 @@ def bench_batch_norm_forward(num_vec, vec_sz, ctx):
         )
 
 
-@util.report("backward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 20})
+@util.report("backward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 20})
 def bench_batch_norm_backward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda", requires_grad=True)
 

--- a/benchmarks/benchmark_conv2d.py
+++ b/benchmarks/benchmark_conv2d.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "conv2d forward",
-    "wgt_sz",
+    ["wgt_sz"],
     [3 * i for i in range(1, 21)],
     {"num_bt": 2, "inp_ch": 3, "inp_sz": 256, "out_ch": 8},
 )

--- a/benchmarks/benchmark_dropout.py
+++ b/benchmarks/benchmark_dropout.py
@@ -19,7 +19,7 @@ import util
 import trident
 
 
-@util.report("dropout forward", "inp_sz", [512 * i for i in range(1, 21)], {"p": 0.5})
+@util.report("dropout forward", ["inp_sz"], [512 * i for i in range(1, 21)], {"p": 0.5})
 def bench_dropout_forward(p, inp_sz, ctx):
     inp = torch.randn(inp_sz, device="cuda")
 

--- a/benchmarks/benchmark_gelu.py
+++ b/benchmarks/benchmark_gelu.py
@@ -19,7 +19,9 @@ import util
 import trident
 
 
-@util.report("gelu forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 1})
+@util.report(
+    "gelu forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 1}
+)
 def bench_gelu_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")
 

--- a/benchmarks/benchmark_instance_norm.py
+++ b/benchmarks/benchmark_instance_norm.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "instance norm forward",
-    "vec_sz",
+    ["vec_sz"],
     [256 * i for i in range(1, 21)],
     {"num_bt": 32, "num_ch": 64},
 )

--- a/benchmarks/benchmark_layer_norm.py
+++ b/benchmarks/benchmark_layer_norm.py
@@ -19,7 +19,7 @@ import util
 import trident
 
 
-@util.report("forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 3})
+@util.report("forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 3})
 def bench_layer_norm_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")
     norm_sh = (inp.shape[-1],)
@@ -34,7 +34,7 @@ def bench_layer_norm_forward(num_vec, vec_sz, ctx):
         )
 
 
-@util.report("backward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 3})
+@util.report("backward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 3})
 def bench_layer_norm_backward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda", requires_grad=True)
     norm_sh = [inp.shape[-1]]

--- a/benchmarks/benchmark_leaky_relu.py
+++ b/benchmarks/benchmark_leaky_relu.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "leaky relu forward",
-    "vec_sz",
+    ["vec_sz"],
     [256 * i for i in range(1, 21)],
     {"num_vec": 64},
 )

--- a/benchmarks/benchmark_max_pool2d.py
+++ b/benchmarks/benchmark_max_pool2d.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "max pool2d forward",
-    "knl_sz",
+    ["knl_sz"],
     [3 * i for i in range(1, 21)],
     {"num_bt": 2, "num_ch": 3, "h": 512, "w": 512},
 )

--- a/benchmarks/benchmark_prelu.py
+++ b/benchmarks/benchmark_prelu.py
@@ -20,7 +20,7 @@ import trident
 
 
 @util.report(
-    "prelu forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 16}
+    "prelu forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 16}
 )
 def bench_prelu_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")

--- a/benchmarks/benchmark_relu.py
+++ b/benchmarks/benchmark_relu.py
@@ -19,7 +19,9 @@ import util
 import trident
 
 
-@util.report("relu forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 32})
+@util.report(
+    "relu forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 32}
+)
 def bench_relu_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")
 

--- a/benchmarks/benchmark_silu.py
+++ b/benchmarks/benchmark_silu.py
@@ -19,7 +19,9 @@ import util
 import trident
 
 
-@util.report("silu forward", "vec_sz", [256 * i for i in range(1, 21)], {"num_vec": 1})
+@util.report(
+    "silu forward", ["vec_sz"], [256 * i for i in range(1, 21)], {"num_vec": 1}
+)
 def bench_silu_forward(num_vec, vec_sz, ctx):
     inp = torch.randn(num_vec, vec_sz, device="cuda")
 

--- a/benchmarks/benchmark_softmax.py
+++ b/benchmarks/benchmark_softmax.py
@@ -21,7 +21,7 @@ import trident
 
 @util.report(
     "softmax forward",
-    "vec_sz",
+    ["vec_sz"],
     [256 * i for i in range(1, 21)],
     {"num_bt": 32},
 )
@@ -36,7 +36,7 @@ def bench_softmax_forward(num_bt, vec_sz, ctx):
 
 @util.report(
     "softmax backward",
-    "vec_sz",
+    ["vec_sz"],
     [256 * i for i in range(1, 21)],
     {"num_bt": 32},
 )

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -15,9 +15,9 @@
 import triton
 
 
-def make_benchmark(title, x_name, x_vals, args):
+def make_benchmark(title, x_names, x_vals, args):
     return triton.testing.Benchmark(
-        [x_name],
+        x_names,
         x_vals,
         "ctx",
         ["torch", "trident"],
@@ -29,5 +29,7 @@ def make_benchmark(title, x_name, x_vals, args):
     )
 
 
-def report(title, x_name, x_vals, args):
-    return triton.testing.perf_report(make_benchmark(title, x_name, x_vals, args))
+def report(title, x_names, x_vals, args=None):
+    if args is None:
+        args = {}
+    return triton.testing.perf_report(make_benchmark(title, x_names, x_vals, args))

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -19,33 +19,56 @@ import trident
 from tests import util
 
 
-def test_function(device):
-    inp = torch.randn(512, 512, device=device)
-    wgt = torch.randn(512, 512, device=device)
+@pytest.mark.parametrize(
+    "num_bt, inp_feat, out_feat, act",
+    [(512, 512, 100, "relu"), (200, 120, 15, "leaky_relu")],
+)
+def test_forward(num_bt, inp_feat, out_feat, act, device):
+    inp = torch.randn(num_bt, inp_feat, device=device)
+    wgt = torch.randn(out_feat, inp_feat, device=device)
+    bis = torch.randn(out_feat, device=device)
 
     assert util.equal(
         torch.nn.functional.linear(inp, wgt), trident.function.linear(inp, wgt)
     )
-
-
-def test_function_with_bias(device):
-    inp = torch.randn(512, 512, device=device)
-    wgt = torch.randn(512, 512, device=device)
-    bis = torch.randn(512, device=device)
 
     assert util.equal(
         torch.nn.functional.linear(inp, wgt, bis),
         trident.function.linear(inp, wgt, bis),
     )
 
-
-@pytest.mark.parametrize("act", ["relu", "leaky_relu"])
-def test_function_with_activation(act, device):
-    inp = torch.randn(512, 512, device=device)
-    wgt = torch.randn(512, 512, device=device)
-    bis = torch.randn(512, device=device)
-
     assert util.equal(
         util.activate(torch.nn.functional.linear(inp, wgt, bis), act),
         trident.function.linear(inp, wgt, bis, act),
     )
+
+
+@pytest.mark.parametrize(
+    "num_bt, inp_feat, out_feat, act",
+    [(12, 34, 3, "relu"), (43, 12, 2, "leaky_relu")],
+)
+def test_backward(num_bt, inp_feat, out_feat, act, device):
+    inp = torch.randn(num_bt, inp_feat, device=device)
+    wgt = torch.randn(out_feat, inp_feat, device=device)
+    bis = torch.randn(out_feat, device=device)
+
+    tgt = torch.randn(num_bt, out_feat, device=device)
+
+    x = inp.clone()
+    a = inp.clone()
+    x.requires_grad = a.requires_grad = True
+
+    lyr0 = torch.nn.Linear(inp_feat, out_feat, True, device=device)
+    lyr0.weight = torch.nn.Parameter(wgt)
+    lyr0.bias = torch.nn.Parameter(bis)
+
+    lyr1 = trident.Linear(inp_feat, out_feat, True, activation=act)
+    lyr1.weight = torch.nn.Parameter(wgt)
+    lyr1.bias = torch.nn.Parameter(bis)
+
+    util.train(x, tgt, lyr0, act)
+    util.train(a, tgt, lyr1)
+
+    assert util.equal(x.grad, a.grad)
+    assert util.equal(lyr0.weight.grad, lyr1.weight.grad)
+    assert util.equal(lyr0.bias.grad, lyr1.bias.grad)

--- a/tests/util.py
+++ b/tests/util.py
@@ -19,10 +19,12 @@ def equal(a, b):
     return torch.allclose(a, b, atol=1e-2, rtol=0)
 
 
-def train(inp, tgt, mod, crit=torch.nn.MSELoss()):
+def train(inp, tgt, mod, act=None, crit=torch.nn.MSELoss()):
     out = mod(inp)
-    out.retain_grad()
+    if act is not None:
+        out = activate(out, act)
 
+    out.retain_grad()
     crit(out, tgt).backward()
 
     return out

--- a/trident/module.py
+++ b/trident/module.py
@@ -349,7 +349,7 @@ class LeakyReLU(torch.nn.Module):
 
 
 class Linear(torch.nn.Module):
-    def __init__(self, in_features, out_features, bias=True):
+    def __init__(self, in_features, out_features, bias=True, activation=None):
         """
         Applies Linear Transformation to an input.
 
@@ -357,17 +357,20 @@ class Linear(torch.nn.Module):
             in_features: size of each input sample
             out_features: size of each output sample
             bias: If set to False, the layer will not learn an additive bias
+            activation: activation function
         """
         super().__init__()
 
         self.weight = torch.nn.Parameter(
-            torch.randn(out_features, in_features, device="cuda")
+            torch.empty(out_features, in_features, device="cuda")
         )
-        self.bias = (
-            torch.nn.Parameter(torch.randn(out_features, device="cuda"))
-            if bias
-            else None
-        )
+
+        if bias:
+            self.bias = torch.nn.Parameter(torch.empty(out_features, device="cuda"))
+        else:
+            self.register_parameter("bias", None)
+
+        self.activation = activation
 
     def forward(self, input):
         """
@@ -379,7 +382,7 @@ class Linear(torch.nn.Module):
         Returns:
             an output (*, out_features)
         """
-        return operation.Linear.apply(input, self.weight, self.bias)
+        return function.linear(input, self.weight, self.bias, self.activation)
 
 
 class MaxPool2d(torch.nn.Module):


### PR DESCRIPTION
## 🙏 Describe the pull request

- Linear의 순전파의 성능을 개선했습니다.
- Linear의 벤치마크를 정방 행렬(M=K=N)을 사용해서 측정하도록 수정하였습니다.
- Linear의 역전파를 구현했습니다.

## 💬 Additional context

`dot`의 `allow_tf32`와 `block pointer`를 사용하면 성능이 매우 좋아 집니다. 하지만 정밀도 차이가 발생하여 비활성화 합니다. 오차 허용을 증가(`atol=1e-1`)시키면 테스트에 통과합니다.

After:

![plot](https://github.com/kakaobrain/trident/assets/117069362/09277f9b-3053-49b5-87bb-3ae8fae3cc27)

Before:

![plot](https://github.com/kakaobrain/trident/assets/117069362/9129a0ea-d1e5-4587-a431-390caa9947de)

After with TF32:

![plot](https://github.com/kakaobrain/trident/assets/117069362/a41bd65b-5ba3-4cb8-ba8b-505f61e96d36)

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.