### PR TITLE
Optimize GroupNorm

### DIFF
--- a/benchmarks/benchmark_group_norm.py
+++ b/benchmarks/benchmark_group_norm.py
@@ -21,9 +21,9 @@ import trident
 
 @util.report(
     "group norm forward",
-    ["x_size"],
-    [256 * i for i in range(1, 21)],
-    {"num_batches": 4, "y_size": 256, "num_groups": 128},
+    ["y_size"],
+    [320 * i for i in range(1, 11)],
+    {"num_batches": 2, "x_size": 64, "num_groups": 32},
 )
 def bench_group_norm_forward(num_batches, y_size, x_size, num_groups, backend):
     input = torch.randn((num_batches, y_size, x_size), device="cuda")
@@ -36,20 +36,20 @@ def bench_group_norm_forward(num_batches, y_size, x_size, num_groups, backend):
 
 @util.report(
     "group norm backward",
-    ["x_size"],
-    [256 * i for i in range(1, 21)],
-    {"num_batches": 4, "y_size": 256, "num_groups": 128},
+    ["y_size"],
+    [320 * i for i in range(1, 11)],
+    {"num_batches": 2, "x_size": 64, "num_groups": 32},
 )
 def bench_group_norm_backward(num_batches, y_size, x_size, num_groups, backend):
     input = torch.randn((num_batches, y_size, x_size), device="cuda", requires_grad=True)
-    target = torch.randn((num_batches, y_size, x_size), device="cuda")
+    grad_output = torch.randn((num_batches, y_size, x_size), device="cuda")
 
     if backend == "torch":
         output = torch.group_norm(input, num_groups)
     else:
         output = trident.function.group_norm(input, num_groups)
 
-    return triton.testing.do_bench_cudagraph(lambda: output.backward(target, retain_graph=True))
+    return triton.testing.do_bench_cudagraph(lambda: output.backward(grad_output, retain_graph=True))
 
 
 def run_benchmark(mode, show_plots):

--- a/trident/function/function.py
+++ b/trident/function/function.py
@@ -94,9 +94,10 @@ def group_norm(input, num_groups, weight=None, bias=None, eps=1e-05):
 
     See GroupNorm for details.
     """
-    return operation.GroupNorm.apply(
+    output, _, _ = operation.GroupNorm.apply(
         input.view(input.shape[0], input.shape[1], -1), num_groups, weight, bias, eps
-    ).view(input.shape)
+    )
+    return output.view(input.shape)
 
 
 def instance_norm(

--- a/trident/kernel/group_norm.py
+++ b/trident/kernel/group_norm.py
@@ -18,87 +18,72 @@ import triton.language as tl
 from trident import language
 
 
-def configs_for_forward():
-    configs = []
-    for num_stages in [2, 3, 4]:
-        for num_warps in [4, 8]:
-            for x_block_size in [128, 256, 512]:
-                config = triton.Config(
-                    {"x_block_size": x_block_size},
-                    num_stages=num_stages,
-                    num_warps=num_warps,
-                )
-                configs.append(config)
-    return configs
-
-
 class GroupNorm:
     @staticmethod
-    @triton.autotune(
-        configs=configs_for_forward(),
-        key=["x_size"],
-    )
     @triton.jit
     def forward(
-        output_ptr,
-        input_ptr,
-        y_size,
-        x_size,
-        num_groups,
-        weight_ptr,
-        bias_ptr,
-        eps,
-        x_block_size: tl.constexpr,
-        group_block_size: tl.constexpr,
+        output_ptr: tl.tensor,
+        input_ptr: tl.tensor,
+        rstd_ptr: tl.tensor,
+        mean_ptr: tl.tensor,
+        y_size: tl.int32,
+        x_size: tl.int32,
+        num_groups: tl.int32,
+        weight_ptr: tl.tensor,
+        bias_ptr: tl.tensor,
+        eps: tl.float32,
         dtype: tl.constexpr,
+        y_block_size: tl.constexpr,
+        x_block_size: tl.constexpr,
     ):
         group_size = y_size // num_groups
         pid = tl.program_id(0)
         batch = pid // num_groups
         group = pid % num_groups
         batch_offset = batch * y_size * x_size
-        group_offset = group * group_size * x_size
-
-        mean = language.Mean.forward(
-            input_ptr + batch_offset,
-            num_groups,
-            x_size * group_size,
-            x_size * group_size,
-            1,
-            group,
-            dtype,
-            x_block_size,
-        )
-        var = language.Var.forward(
-            input_ptr + batch_offset,
-            num_groups,
-            x_size * group_size,
-            x_size * group_size,
-            1,
-            group,
-            mean,
-            language.zero,
-            dtype,
-            x_block_size,
-        )
-        std = language.std(var, eps)
-
-        input_block_ptr = tl.make_block_ptr(
-            input_ptr + batch_offset + group_offset,
-            shape=(group_size, x_size),
-            strides=(x_size, 1),
-            offsets=(0, 0),
-            block_shape=(group_block_size, x_block_size),
-            order=(1, 0),
-        )
+        num_elements = group_size * x_size
+        group_offset = batch_offset + group * num_elements
         output_block_ptr = tl.make_block_ptr(
-            output_ptr + batch_offset + group_offset,
+            output_ptr + group_offset,
             shape=(group_size, x_size),
             strides=(x_size, 1),
             offsets=(0, 0),
-            block_shape=(group_block_size, x_block_size),
+            block_shape=(y_block_size, x_block_size),
             order=(1, 0),
         )
+        input_block_ptr = tl.make_block_ptr(
+            input_ptr + group_offset,
+            shape=(group_size, x_size),
+            strides=(x_size, 1),
+            offsets=(0, 0),
+            block_shape=(y_block_size, x_block_size),
+            order=(1, 0),
+        )
+        rstd_block_ptr = tl.make_block_ptr(
+            rstd_ptr + batch * num_groups,
+            shape=(group_size,),
+            strides=(1,),
+            offsets=(group,),
+            block_shape=(1,),
+            order=(0,),
+        )
+        mean_block_ptr = tl.make_block_ptr(
+            mean_ptr + batch * num_groups,
+            shape=(group_size,),
+            strides=(1,),
+            offsets=(group,),
+            block_shape=(1,),
+            order=(0,),
+        )
+        input = tl.load(input_block_ptr, boundary_check=(1,), padding_option="zero")
+        mean = tl.sum(tl.view(input, (1, y_block_size * x_block_size)), 1) / num_elements
+        y_condition = tl.arange(0, y_block_size) < group_size
+        x_condition = tl.arange(0, x_block_size) < x_size
+        condition = y_condition[:, None] & x_condition[None, :]
+        centered_mean = tl.where(condition, input - mean, 0)
+        var = tl.sum(tl.view(centered_mean * centered_mean, (1, y_block_size * x_block_size)), 1) / num_elements
+        rstd = tl.math.rsqrt(var + eps)
+        output = centered_mean * rstd
 
         if weight_ptr is not None:
             weight_block_ptr = tl.make_block_ptr(
@@ -106,12 +91,11 @@ class GroupNorm:
                 shape=(y_size, 1),
                 strides=(1, y_size),
                 offsets=(group * group_size, 0),
-                block_shape=(group_block_size, 1),
+                block_shape=(y_block_size, 1),
                 order=(0, 1),
             )
             weight = tl.load(weight_block_ptr, boundary_check=(0,))
-        else:
-            weight = None
+            output *= weight
 
         if bias_ptr is not None:
             bias_block_ptr = tl.make_block_ptr(
@@ -119,98 +103,89 @@ class GroupNorm:
                 shape=(y_size, 1),
                 strides=(1, y_size),
                 offsets=(group * group_size, 0),
-                block_shape=(group_block_size, 1),
+                block_shape=(y_block_size, 1),
                 order=(0, 1),
             )
             bias = tl.load(bias_block_ptr, boundary_check=(0,))
-        else:
-            bias = None
+            output += bias
 
-        for _ in range(0, x_size, x_block_size):
-            input = tl.load(input_block_ptr, boundary_check=(0, 1))
-            output = language.norm(input, mean, std)
-
-            if weight is not None:
-                output *= weight
-
-            if bias is not None:
-                output += bias
-
-            tl.store(output_block_ptr, output.to(dtype), boundary_check=(0, 1))
-            input_block_ptr = tl.advance(input_block_ptr, (0, x_block_size))
-            output_block_ptr = tl.advance(output_block_ptr, (0, x_block_size))
+        tl.store(output_block_ptr, output.to(dtype), boundary_check=(0, 1))
+        tl.store(rstd_block_ptr, rstd.to(dtype))
+        tl.store(mean_block_ptr, mean.to(dtype))
 
     @staticmethod
     @triton.jit
     def backward(
-        grad_input_ptr,
-        grad_weight_staging_ptr,
-        grad_bias_staging_ptr,
-        grad_output_ptr,
-        input_ptr,
-        y_size,
-        x_size,
-        num_groups,
-        weight_ptr,
-        eps,
-        x_block_size: tl.constexpr,
-        group_block_size: tl.constexpr,
+        grad_input_ptr: tl.tensor,
+        grad_weight_staging_ptr: tl.tensor,
+        grad_bias_staging_ptr: tl.tensor,
+        grad_output_ptr: tl.tensor,
+        input_ptr: tl.tensor,
+        y_size: tl.int32,
+        x_size: tl.int32,
+        num_groups: tl.int32,
+        weight_ptr: tl.tensor,
+        rstd_ptr: tl.tensor,
+        mean_ptr: tl.tensor,
         dtype: tl.constexpr,
+        y_block_size: tl.constexpr,
+        x_block_size: tl.constexpr,
     ):
         group_size = y_size // num_groups
         pid = tl.program_id(0)
         batch = pid // num_groups
         group = pid % num_groups
         batch_offset = batch * y_size * x_size
-        group_offset = group * group_size * x_size
-
-        mean = language.Mean.forward(
-            input_ptr + batch_offset,
-            num_groups,
-            x_size * group_size,
-            x_size * group_size,
-            1,
-            group,
-            dtype,
-            x_block_size,
-        )
-        var = language.Var.forward(
-            input_ptr + batch_offset,
-            num_groups,
-            x_size * group_size,
-            x_size * group_size,
-            1,
-            group,
-            mean,
-            language.zero,
-            dtype,
-            x_block_size,
-        )
-        std = language.std(var, eps)
-
-        input_block_ptr = tl.make_block_ptr(
-            input_ptr + batch_offset + group_offset,
+        num_elements = group_size * x_size
+        group_offset = batch_offset + group * num_elements
+        grad_input_block_ptr = tl.make_block_ptr(
+            grad_input_ptr + group_offset,
             shape=(group_size, x_size),
             strides=(x_size, 1),
             offsets=(0, 0),
-            block_shape=(group_block_size, x_block_size),
+            block_shape=(y_block_size, x_block_size),
             order=(1, 0),
         )
+        grad_output_block_ptr = tl.make_block_ptr(
+            grad_output_ptr + group_offset,
+            shape=(group_size, x_size),
+            strides=(x_size, 1),
+            offsets=(0, 0),
+            block_shape=(y_block_size, x_block_size),
+            order=(1, 0),
+        )
+        input_block_ptr = tl.make_block_ptr(
+            input_ptr + group_offset,
+            shape=(group_size, x_size),
+            strides=(x_size, 1),
+            offsets=(0, 0),
+            block_shape=(y_block_size, x_block_size),
+            order=(1, 0),
+        )
+        rstd_block_ptr = tl.make_block_ptr(
+            rstd_ptr + batch * num_groups,
+            shape=(group_size,),
+            strides=(1,),
+            offsets=(group,),
+            block_shape=(1,),
+            order=(0,),
+        )
+        mean_block_ptr = tl.make_block_ptr(
+            mean_ptr + batch * num_groups,
+            shape=(group_size,),
+            strides=(1,),
+            offsets=(group,),
+            block_shape=(1,),
+            order=(0,),
+        )
+        grad_output = tl.load(grad_output_block_ptr, boundary_check=(0, 1))
         input = tl.load(input_block_ptr, boundary_check=(0, 1))
-        y_condition = tl.arange(0, group_block_size) < group_size
+        rstd = tl.load(rstd_block_ptr)
+        mean = tl.load(mean_block_ptr)
+        y_condition = tl.arange(0, y_block_size) < group_size
         x_condition = tl.arange(0, x_block_size) < x_size
         condition = y_condition[:, None] & x_condition[None, :]
         centered_mean = tl.where(condition, input - mean, 0)
-
-        grad_output_block_ptr = tl.make_block_ptr(
-            grad_output_ptr + batch_offset + group_offset,
-            shape=(group_size, x_size),
-            strides=(x_size, 1),
-            offsets=(0, 0),
-            block_shape=(group_block_size, x_block_size),
-            order=(1, 0),
-        )
-        grad_output = tl.load(grad_output_block_ptr, boundary_check=(0, 1))
 
         if weight_ptr is not None:
             weight_block_ptr = tl.make_block_ptr(
@@ -218,7 +193,7 @@ class GroupNorm:
                 shape=(y_size, 1),
                 strides=(1, y_size),
                 offsets=(group * group_size, 0),
-                block_shape=(group_block_size, 1),
+                block_shape=(y_block_size, 1),
                 order=(0, 1),
             )
             weight = tl.load(weight_block_ptr, boundary_check=(0,))
@@ -226,50 +201,37 @@ class GroupNorm:
         else:
             grad_norm = grad_output
 
-        grad_std = tl.sum(grad_norm * centered_mean, 1)
-        grad_std = tl.sum(grad_std, 0)
-        grad_var = grad_std / (-language.pow2(std) * 2 * std * x_size * group_size)
+        grad_std = tl.sum(tl.view(grad_norm * centered_mean, (1, y_block_size * x_block_size)), 1)
+        grad_var = grad_std * -(0.5 * rstd * rstd * rstd) / (x_size * group_size)
         grad_distance = 2 * centered_mean * grad_var
-        grad_centered_mean = tl.where(condition, (grad_norm / std) + grad_distance, 0)
-        grad_mean = tl.sum(grad_centered_mean, 1) / x_size
-        grad_mean = -tl.sum(grad_mean, 0) / group_size
+        grad_centered_mean = tl.where(condition, grad_norm * rstd + grad_distance, 0)
+        grad_mean = -tl.sum(tl.view(grad_centered_mean, (1, y_block_size * x_block_size)), 1) / num_elements
         grad_input = grad_centered_mean + grad_mean
-
-        grad_input_block_ptr = tl.make_block_ptr(
-            grad_input_ptr + batch_offset + group_offset,
-            shape=(group_size, x_size),
-            strides=(x_size, 1),
-            offsets=(0, 0),
-            block_shape=(group_block_size, x_block_size),
-            order=(1, 0),
-        )
         tl.store(grad_input_block_ptr, grad_input.to(dtype), boundary_check=(0, 1))
 
         if grad_weight_staging_ptr is not None:
-            norm = centered_mean / std
+            norm = centered_mean * rstd
             grad_weight = tl.sum(norm * grad_output, 1)
+            offset = batch * y_size + group * group_size
             grad_weight_staging_block_ptr = tl.make_block_ptr(
-                grad_weight_staging_ptr + batch * y_size + group * group_size,
+                grad_weight_staging_ptr + offset,
                 shape=(group_size,),
                 strides=(1,),
                 offsets=(0,),
-                block_shape=(group_block_size,),
+                block_shape=(y_block_size,),
                 order=(0,),
             )
-            tl.store(
-                grad_weight_staging_block_ptr,
-                grad_weight.to(dtype),
-                boundary_check=(0,),
-            )
+            tl.store(grad_weight_staging_block_ptr, grad_weight.to(dtype), boundary_check=(0,))
 
         if grad_bias_staging_ptr is not None:
             grad_bias = tl.sum(grad_output, 1)
+            offset = batch * y_size + group * group_size
             grad_bias_staging_block_ptr = tl.make_block_ptr(
-                grad_bias_staging_ptr + batch * y_size + group * group_size,
+                grad_bias_staging_ptr + offset,
                 shape=(group_size,),
                 strides=(1,),
                 offsets=(0,),
-                block_shape=(group_block_size,),
+                block_shape=(y_block_size,),
                 order=(0,),
             )
             tl.store(grad_bias_staging_block_ptr, grad_bias.to(dtype), boundary_check=(0,))


### PR DESCRIPTION
## 🙏 Describe the pull request

GroupNorm is optimized.

## 💬 Additional context

The performance of backward can be slow very easily. Because it's easy to exceed the shared memory size.

Forward:

![forward](https://github.com/kakaobrain/trident/assets/7459074/bccddf69-9575-4227-88b1-68b7c5b37d05)

Backward:

![backward](https://github.com/kakaobrain/trident/assets/7459074/ef610913-72c6-4af2-a85e-9604aeab92e3)

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.