### PR TITLE
Optimize LayerNorm

### DIFF
--- a/examples/playground.py
+++ b/examples/playground.py
@@ -14,5 +14,6 @@
 
 import torch
 import triton
+import triton.language as tl
 
 import trident

--- a/tests/test_mean.py
+++ b/tests/test_mean.py
@@ -19,7 +19,7 @@ import trident
 from tests import util
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(1000, 2000, 0), (2000, 1000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(4, 2000, 0), (2000, 4, 1)])
 def test_forward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)
@@ -27,7 +27,7 @@ def test_forward(y_size, x_size, dim, device, dtype):
     assert util.equal(torch.mean(input, dim), trident.function.mean(input, dim))
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 1000, 0), (1000, 2000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 4, 0), (4, 2000, 1)])
 def test_backward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)
@@ -45,7 +45,7 @@ def test_backward(y_size, x_size, dim, device, dtype):
     assert util.equal(x, a)
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(16, 32, 0), (32, 16, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(1, 16, 0), (16, 1, 1)])
 def test_mean(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -19,7 +19,7 @@ import trident
 from tests import util
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(1000, 2000, 0), (2000, 1000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(4, 2000, 0), (2000, 4, 1)])
 def test_forward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)
@@ -27,7 +27,7 @@ def test_forward(y_size, x_size, dim, device, dtype):
     assert util.equal(torch.var(input, dim), trident.function.var(input, dim))
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 1000, 0), (1000, 2000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 4, 0), (4, 2000, 1)])
 def test_backward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)
@@ -45,7 +45,7 @@ def test_backward(y_size, x_size, dim, device, dtype):
     assert util.equal(x, a)
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(32, 16, 0), (16, 32, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(1, 16, 0), (16, 1, 1)])
 def test_mean(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)

--- a/tests/test_var_mean.py
+++ b/tests/test_var_mean.py
@@ -19,7 +19,7 @@ import trident
 from tests import util
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(1000, 2000, 0), (2000, 1000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(4, 2000, 0), (2000, 4, 1)])
 def test_forward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)
@@ -31,7 +31,7 @@ def test_forward(y_size, x_size, dim, device, dtype):
     assert util.equal(y, b)
 
 
-@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 1000, 0), (1000, 2000, 1)])
+@pytest.mark.parametrize("y_size, x_size, dim", [(2000, 4, 0), (4, 2000, 1)])
 def test_backward(y_size, x_size, dim, device, dtype):
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(y_size, x_size, **factory_kwargs)

--- a/trident/function/function.py
+++ b/trident/function/function.py
@@ -132,7 +132,8 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-05):
 
     See LayerNorm for details.
     """
-    return operation.LayerNorm.apply(input, normalized_shape, weight, bias, eps)
+    output, _, _ = operation.LayerNorm.apply(input, normalized_shape, weight, bias, eps)
+    return output
 
 
 def leaky_relu(input, negative_slope=0.01):

--- a/trident/kernel/mean.py
+++ b/trident/kernel/mean.py
@@ -80,15 +80,5 @@ class Mean:
             block_shape=(1, x_block_size),
             order=(0, 1),
         )
-        grad_output_block_ptr = tl.make_block_ptr(
-            grad_output_ptr,
-            shape=(y_size, 1),
-            strides=(1, 0),
-            offsets=(y_offset, 0),
-            block_shape=(1, 1),
-            order=(0, 1),
-        )
-        grad_mean = language.Mean.backward(x_size, dtype, x_block_size)
-        grad_output = tl.load(grad_output_block_ptr)
-        grad_input = grad_mean * grad_output
+        grad_input = language.Mean.backward(grad_output_ptr, y_size, x_size, y_offset, dtype, x_block_size)
         tl.store(grad_input_block_ptr, grad_input, boundary_check=(1,))

--- a/trident/kernel/var.py
+++ b/trident/kernel/var.py
@@ -93,18 +93,19 @@ class Var:
             block_shape=(1, x_block_size),
             order=(1, 0),
         )
-        grad_output_block_ptr = tl.make_block_ptr(
-            grad_output_ptr,
-            shape=(y_size, 1),
-            strides=(1, 0),
-            offsets=(y_offset, 0),
-            block_shape=(1, 1),
-            order=(1, 0),
-        )
-        grad_output = tl.load(grad_output_block_ptr)
         mean = language.Mean.forward(input_ptr, y_size, x_size, y_stride, x_stride, y_offset, dtype, x_block_size)
-        grad_var = language.Var.backward(
-            input_ptr, y_size, x_size, y_stride, x_stride, y_offset, x_offset, mean, correction, dtype, x_block_size
+        grad_input = language.Var.backward(
+            grad_output_ptr,
+            input_ptr,
+            y_size,
+            x_size,
+            y_stride,
+            x_stride,
+            y_offset,
+            x_offset,
+            mean,
+            correction,
+            dtype,
+            x_block_size,
         )
-        grad_input = grad_output * grad_var
         tl.store(grad_input_block_ptr, grad_input, boundary_check=(1,))

--- a/trident/kernel/var_mean.py
+++ b/trident/kernel/var_mean.py
@@ -104,14 +104,6 @@ class VarMean:
             block_shape=(1, x_block_size),
             order=(1, 0),
         )
-        grad_output_block_ptr = tl.make_block_ptr(
-            grad_output_ptr,
-            shape=(y_size, 1),
-            strides=(1, 0),
-            offsets=(y_offset, 0),
-            block_shape=(1, 1),
-            order=(1, 0),
-        )
         mean_block_ptr = tl.make_block_ptr(
             mean_ptr,
             shape=(y_size,),
@@ -120,10 +112,19 @@ class VarMean:
             block_shape=(1,),
             order=(0,),
         )
-        grad_output = tl.load(grad_output_block_ptr)
         mean = tl.load(mean_block_ptr)
-        grad_var = language.VarMean.backward(
-            input_ptr, y_size, x_size, y_stride, x_stride, y_offset, x_offset, mean, correction, dtype, x_block_size
+        grad_input = language.Var.backward(
+            grad_output_ptr,
+            input_ptr,
+            y_size,
+            x_size,
+            y_stride,
+            x_stride,
+            y_offset,
+            x_offset,
+            mean,
+            correction,
+            dtype,
+            x_block_size,
         )
-        grad_input = grad_output * grad_var
         tl.store(grad_input_block_ptr, grad_input, boundary_check=(1,))

--- a/trident/language/var.py
+++ b/trident/language/var.py
@@ -57,6 +57,7 @@ class Var:
     @staticmethod
     @triton.jit
     def backward(
+        grad_output_ptr: tl.tensor,
         input_ptr: tl.tensor,
         y_size: int,
         x_size: int,
@@ -69,6 +70,14 @@ class Var:
         dtype: tl.constexpr,
         x_block_size: tl.constexpr,
     ):
+        grad_output_block_ptr = tl.make_block_ptr(
+            grad_output_ptr,
+            shape=(y_size, 1),
+            strides=(1, 0),
+            offsets=(y_offset, 0),
+            block_shape=(1, 1),
+            order=(1, 0),
+        )
         input_block_ptr = tl.make_block_ptr(
             input_ptr,
             shape=(y_size, x_size),
@@ -77,9 +86,10 @@ class Var:
             block_shape=(1, x_block_size),
             order=(1, 0),
         )
+        grad_output = tl.load(grad_output_block_ptr)
         input = tl.load(input_block_ptr, boundary_check=(1,))
         condition = tl.arange(0, x_block_size) + x_offset < x_size
         centered_mean = tl.where(condition[None, :], input - mean, 0.0)
-        grad_input = 2 * centered_mean / (x_size - correction)
+        grad_input = grad_output * 2 * centered_mean / (x_size - correction)
 
         return grad_input.to(dtype)


### PR DESCRIPTION
## 🙏 Describe the pull request

- Optimize kernels in practice.
- Saving the the computationally intensive results during forward and use them in backward.

## 💬 Additional context

The number of batch is 512 and the size of y is 2048 are used to measure the performance.

Forward:

![forward](https://github.com/kakaobrain/trident/assets/7459074/9e416eeb-76ff-4263-8316-f3911cd78f94)

```
layer norm forward:
    x_size     torch   trident
0    128.0  0.033692  0.027340
1    256.0  0.033113  0.027507
2    384.0  0.036455  0.029943
3    512.0  0.040629  0.032816
4    640.0  0.049242  0.038687
5    768.0  0.051576  0.040833
6    896.0  0.053890  0.044940
7   1024.0  0.057740  0.049299
8   1152.0  0.065654  0.056566
9   1280.0  0.069426  0.060125
10  1408.0  0.072669  0.064212
11  1536.0  0.076262  0.068369
12  1664.0  0.083951  0.072805
13  1792.0  0.088486  0.077547
14  1920.0  0.093037  0.082433
15  2048.0  0.097137  0.087765
16  2176.0  0.104748  0.098911
17  2304.0  0.108579  0.101484
18  2432.0  0.113030  0.104974
19  2560.0  0.118548  0.109208
```


Backward:

![backward](https://github.com/kakaobrain/trident/assets/7459074/dbbbd66a-69a6-48aa-8a36-b54925f59b04)

```
layer norm backward:
    x_size      torch    trident
0    128.0   8.631920   3.132625
1    256.0  10.128368   5.702687
2    384.0  12.168322   8.327372
3    512.0  14.228138  11.061963
4    640.0  16.423538  13.890116
5    768.0  18.566242  16.554686
6    896.0  20.790047  19.286476
7   1024.0  23.174767  21.956993
8   1152.0  25.614109  24.940414
9   1280.0  28.328491  27.638433
10  1408.0  31.111601  30.340252
11  1536.0  33.773621  33.064259
12  1664.0  37.148376  35.783253
13  1792.0  40.412640  38.440395
14  1920.0  43.625992  41.012562
15  2048.0  46.177559  43.656803
16  2176.0  50.539066  46.873379
17  2304.0  53.710068  49.640415
18  2432.0  57.216782  52.175392
19  2560.0  60.152634  54.884762
```

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.