### PR TITLE
Implement ShiftGELU

### DIFF
--- a/benchmarks/benchmark_shift_gelu.py
+++ b/benchmarks/benchmark_shift_gelu.py
@@ -1,0 +1,56 @@
+# Copyright 2023 ⓒ Kakao Brain Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+import triton.language as tl
+import util
+
+import trident
+
+
+def shift_gelu(input: torch.Tensor, bias: torch.Tensor):
+    return torch.nn.functional.gelu(input + bias)
+
+
+@util.report("shift gelu forward", ["x_size"], [512 * i for i in range(1, 21)], {"num_batches": 2048, "y_size": 16})
+def bench_shift_gelu_forward(num_batches, y_size, x_size, backend):
+    input = torch.randn((num_batches, y_size, x_size), device="cuda")
+    bias = torch.randn(x_size, device="cuda")
+
+    if backend == "torch":
+        return triton.testing.do_bench(lambda: shift_gelu(bias, input))
+    else:
+        return triton.testing.do_bench(lambda: trident.function.shift_gelu(input, bias))
+
+
+@util.report("shift gelu backward", ["x_size"], [512 * i for i in range(1, 21)], {"num_batches": 2048, "y_size": 16})
+def bench_shift_gelu_backward(num_batches, y_size, x_size, backend):
+    input = torch.randn((num_batches, y_size, x_size), device="cuda", requires_grad=True)
+    bias = torch.randn(x_size, device="cuda")
+    grad_output = torch.randn((num_batches, y_size, x_size), device="cuda")
+
+    if backend == "torch":
+        output = shift_gelu(input, bias)
+    else:
+        output = trident.function.shift_gelu(input, bias)
+
+    return triton.testing.do_bench_cudagraph(lambda: output.backward(grad_output, retain_graph=True))
+
+
+def run_benchmark(mode, show_plots):
+    if mode == "forward":
+        bench_shift_gelu_forward.run(print_data=True, show_plots=show_plots)
+    else:
+        bench_shift_gelu_backward.run(print_data=True, show_plots=show_plots)

--- a/benchmarks/benchmarker.py
+++ b/benchmarks/benchmarker.py
@@ -34,6 +34,7 @@ import benchmark_mean
 import benchmark_prelu
 import benchmark_relu
 import benchmark_rms_norm
+import benchmark_shift_gelu
 import benchmark_silu
 import benchmark_softmax
 import benchmark_sum
@@ -67,6 +68,7 @@ def print_scenarios():
                 "prelu",
                 "relu",
                 "rms-norm",
+                "shift-gelu",
                 "silu",
                 "softmax",
                 "sum",
@@ -118,6 +120,8 @@ def run_benchmarks(scenario, mode, show_plots):
         benchmark_relu.run_benchmark(mode, show_plots)
     elif scenario == "rms-norm":
         benchmark_rms_norm.run_benchmark(mode, show_plots)
+    elif scenario == "shift-gelu":
+        benchmark_shift_gelu.run_benchmark(mode, show_plots)
     elif scenario == "silu":
         benchmark_silu.run_benchmark(mode, show_plots)
     elif scenario == "softmax":
@@ -149,6 +153,7 @@ def run_benchmarks(scenario, mode, show_plots):
         benchmark_prelu.run_benchmark(mode, show_plots)
         benchmark_relu.run_benchmark(mode, show_plots)
         benchmark_rms_norm.run_benchmark(mode, show_plots)
+        benchmark_shift_gelu.run_benchmark(mode, show_plots)
         benchmark_silu.run_benchmark(mode, show_plots)
         benchmark_softmax.run_benchmark(mode, show_plots)
         benchmark_sum.run_benchmark(mode, show_plots)

--- a/tests/test_shift_gelu.py
+++ b/tests/test_shift_gelu.py
@@ -1,0 +1,59 @@
+# Copyright 2023 ⓒ Kakao Brain Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import trident
+from tests import util
+
+
+def shift_gelu(input: torch.Tensor, bias: torch.Tensor):
+    return torch.nn.functional.gelu(input + bias)
+
+
+@pytest.mark.parametrize("num_batches, y_size, x_size", [(2, 10, 1000)])
+def test_forward(num_batches, y_size, x_size, device):
+    input = torch.randn((num_batches, y_size, x_size), device=device)
+    bias = torch.randn(x_size, device=device)
+
+    assert util.equal(trident.function.shift_gelu(input, bias), shift_gelu(input, bias))
+
+
+@pytest.mark.parametrize("num_batches, y_size, x_size", [(2, 10, 1000)])
+def test_backward(num_batches, y_size, x_size, device):
+    input = torch.randn((num_batches, y_size, x_size), device=device)
+    bias = torch.randn(x_size, device=device)
+    grad_output = torch.rand_like(input)
+
+    def train(func):
+        i = input.clone()
+        j = bias.clone()
+        i.requires_grad = j.requires_grad = True
+        func(i, j).backward(grad_output, retain_graph=True)
+        return i.grad, j.grad
+
+    (x, y) = train(trident.function.shift_gelu)
+    (a, b) = train(shift_gelu)
+
+    assert util.equal(x, a)
+    assert util.equal(y, b)
+
+
+@pytest.mark.parametrize("num_batches, y_size, x_size", [(2, 10, 1000)])
+def test_shift_gelu(num_batches, y_size, x_size, device, dtype):
+    factory_kwargs = {"device": device, "dtype": dtype}
+    input = torch.randn((num_batches, y_size, x_size), **factory_kwargs)
+
+    assert trident.ShiftGELU(x_size, **factory_kwargs).forward(input) is not None

--- a/trident/function/function.py
+++ b/trident/function/function.py
@@ -205,6 +205,16 @@ def rms_norm(input: torch.Tensor, p: float, weight: torch.Tensor, bias: torch.Te
     return output.view(input.shape)
 
 
+def shift_gelu(input: torch.Tensor, bias: torch.Tensor):
+    """
+    Applies shift and the Gaussian Error Linear Units to an input.
+
+    See ShiftGELU for details.
+    """
+    output, _ = operation.ShiftGELU.apply(input.view(-1, input.shape[-1]), bias)
+    return output.view(input.shape)
+
+
 def silu(input):
     """
     Applies the Sigmoid Linear Unit to an input.

--- a/trident/kernel/__init__.py
+++ b/trident/kernel/__init__.py
@@ -33,6 +33,7 @@ from .mean import *
 from .prelu import *
 from .relu import *
 from .rms_norm import *
+from .shift_gelu import *
 from .silu import *
 from .softmax import *
 from .sum import *

--- a/trident/kernel/geglu.py
+++ b/trident/kernel/geglu.py
@@ -103,7 +103,7 @@ class GEGLU:
         )
         tl.store(linear_block_ptr, linear, boundary_check=(0, 1))
 
-        output = language.math.GeLU.forward(linear)
+        output = language.math.GELU.forward(linear)
         output_block_ptr = tl.make_block_ptr(
             output_ptr,
             shape=(m_size, n_size),
@@ -167,7 +167,7 @@ class GEGLU:
         for n_offset in range(0, n_size, n_block_size):
             grad_output = tl.load(grad_output_block_ptr, boundary_check=(0, 1), padding_option="zero")
             linear = tl.load(linear_block_ptr, boundary_check=(0, 1), padding_option="zero")
-            grad_output = language.math.GeLU.backward(grad_output, linear)
+            grad_output = language.math.GELU.backward(grad_output, linear)
             weight = tl.load(weight_block_ptr, boundary_check=(0, 1), padding_option="zero")
             grad_input += tl.dot(grad_output, weight, use_accelerator)
             grad_output_block_ptr = tl.advance(grad_output_block_ptr, (0, n_block_size))
@@ -237,7 +237,7 @@ class GEGLU:
         for m_offset in range(0, m_size, m_block_size):
             grad_output = tl.load(grad_output_block_ptr, boundary_check=(0, 1), padding_option="zero")
             linear = tl.load(linear_block_ptr, boundary_check=(0, 1), padding_option="zero")
-            grad_output = language.math.GeLU.backward(grad_output, linear)
+            grad_output = language.math.GELU.backward(grad_output, linear)
             input = tl.load(input_block_ptr, boundary_check=(0, 1), padding_option="zero")
             grad_weight += tl.dot(grad_output, input, use_accelerator)
             grad_output_block_ptr = tl.advance(grad_output_block_ptr, (0, m_block_size))
@@ -288,7 +288,7 @@ class GEGLU:
         for m_offset in range(0, m_size, block_size):
             grad_output = tl.load(grad_output_block_ptr, boundary_check=(1,), padding_option="zero")
             linear = tl.load(linear_block_ptr, boundary_check=(0, 1), padding_option="zero")
-            grad_output = language.math.GeLU.backward(grad_output, linear)
+            grad_output = language.math.GELU.backward(grad_output, linear)
             sum += grad_output
             grad_output_block_ptr = tl.advance(grad_output_block_ptr, (0, block_size))
             linear_block_ptr = tl.advance(linear_block_ptr, (0, block_size))

--- a/trident/kernel/gelu.py
+++ b/trident/kernel/gelu.py
@@ -42,7 +42,7 @@ class GELU:
         )
 
         input = tl.load(input_block_ptr, boundary_check=(0,))
-        output = language.math.GeLU.forward(input)
+        output = language.math.GELU.forward(input)
         tl.store(output_block_ptr, output.to(dtype), boundary_check=(0,))
 
     @staticmethod
@@ -63,5 +63,5 @@ class GELU:
 
         grad_output = tl.load(grad_output_block_ptr, boundary_check=(0,))
         input = tl.load(input_block_ptr, boundary_check=(0,))
-        grad_input = language.math.GeLU.backward(grad_output, input)
+        grad_input = language.math.GELU.backward(grad_output, input)
         tl.store(grad_input_block_ptr, grad_input.to(dtype), boundary_check=(0,))

--- a/trident/kernel/shift_gelu.py
+++ b/trident/kernel/shift_gelu.py
@@ -1,0 +1,132 @@
+# Copyright 2023 ⓒ Kakao Brain Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import triton
+import triton.language as tl
+
+from trident import language
+
+
+def shift_gelu_configs():
+    configs = []
+    for x_block_size in [256, 512, 1024, 2048]:
+        for num_stages in [4, 5]:
+            config = triton.Config({"x_block_size": x_block_size}, 2 if x_block_size <= 512 else 4, num_stages)
+            configs.append(config)
+    return configs
+
+
+class ShiftGELU:
+    @staticmethod
+    @triton.autotune(shift_gelu_configs(), ["x_size"])
+    @triton.jit
+    def forward(
+        output_ptr: tl.tensor,
+        shift_ptr: tl.tensor,
+        input_ptr: tl.tensor,
+        y_size: tl.int32,
+        x_size: tl.int32,
+        bias_ptr: tl.tensor,
+        dtype: tl.constexpr,
+        x_block_size: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        num_x_blocks = tl.cdiv(x_size, x_block_size)
+        y_offset = pid // num_x_blocks
+        xid = pid % num_x_blocks
+        x_offset = xid * x_block_size
+        output_block_ptr = tl.make_block_ptr(
+            output_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        shift_block_ptr = tl.make_block_ptr(
+            shift_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        input_block_ptr = tl.make_block_ptr(
+            input_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        bias_block_ptr = tl.make_block_ptr(
+            bias_ptr,
+            shape=(1, x_size),
+            strides=(x_size, 1),
+            offsets=(0, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        input = tl.load(input_block_ptr, boundary_check=(1,))
+        bias = tl.load(bias_block_ptr, boundary_check=(1,))
+        shift = input + bias
+        output = language.math.GELU.forward(shift)
+        tl.store(output_block_ptr, output.to(dtype), boundary_check=(1,))
+        tl.store(shift_block_ptr, shift.to(dtype), boundary_check=(1,))
+
+    @staticmethod
+    @triton.autotune(shift_gelu_configs(), ["x_size"])
+    @triton.jit
+    def backward(
+        grad_input_ptr: tl.tensor,
+        grad_output_ptr: tl.tensor,
+        shift_ptr: tl.tensor,
+        y_size: tl.int32,
+        x_size: tl.int32,
+        dtype: tl.constexpr,
+        x_block_size: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        num_x_blocks = tl.cdiv(x_size, x_block_size)
+        y_offset = pid // num_x_blocks
+        xid = pid % num_x_blocks
+        x_offset = xid * x_block_size
+        grad_input_block_ptr = tl.make_block_ptr(
+            grad_input_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        grad_output_block_ptr = tl.make_block_ptr(
+            grad_output_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        shift_block_ptr = tl.make_block_ptr(
+            shift_ptr,
+            shape=(y_size, x_size),
+            strides=(x_size, 1),
+            offsets=(y_offset, x_offset),
+            block_shape=(1, x_block_size),
+            order=(1, 0),
+        )
+        grad_output = tl.load(grad_output_block_ptr, boundary_check=(1,))
+        shift = tl.load(shift_block_ptr, boundary_check=(1,))
+        grad_input = language.math.GELU.backward(grad_output, shift)
+        tl.store(grad_input_block_ptr, grad_input.to(dtype), boundary_check=(1,))

--- a/trident/language/math/gelu.py
+++ b/trident/language/math/gelu.py
@@ -16,7 +16,7 @@ import triton
 import triton.language as tl
 
 
-class GeLU:
+class GELU:
     @staticmethod
     @triton.jit
     def forward(input: tl.tensor):

--- a/trident/module.py
+++ b/trident/module.py
@@ -777,6 +777,37 @@ class RMSNorm(torch.nn.Module):
             util.zero(self.bias)
 
 
+class ShiftGELU(torch.nn.Module):
+    def __init__(self, num_features: torch.int, device=None, dtype=None):
+        """
+        Applies shift and the Gaussian Error Linear Units to an input.
+
+        Args:
+            num_features: number of features
+        """
+        super().__init__()
+
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.bias = torch.nn.Parameter(torch.empty(num_features, **factory_kwargs))
+
+        self.reset_parameters()
+
+    def forward(self, input):
+        """
+        Applies shift and the Gaussian Error Linear Units to an input.
+
+        Args:
+            input: an input
+
+        Returns:
+            an output with the same dimension and shape as an input
+        """
+        return function.shift_gelu(input, self.bias)
+
+    def reset_parameters(self):
+        util.uniform(self.bias, 0.0, 1.0)
+
+
 class SiLU(torch.nn.Module):
     def __init__(self):
         """

--- a/trident/operation/__init__.py
+++ b/trident/operation/__init__.py
@@ -32,6 +32,7 @@ from .mean import *
 from .prelu import *
 from .relu import *
 from .rms_norm import *
+from .shift_gelu import *
 from .silu import *
 from .softmax import *
 from .sum import *

--- a/trident/operation/shift_gelu.py
+++ b/trident/operation/shift_gelu.py
@@ -1,0 +1,62 @@
+# Copyright 2023 ⓒ Kakao Brain Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+
+from trident import kernel, util
+
+
+class ShiftGELU(torch.autograd.Function):
+    @staticmethod
+    def forward(*args, **kwargs):
+        (input, bias) = args
+        return ShiftGELU.__forward(input, bias)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        input, bias = inputs
+        _, shift = output
+        ctx.save_for_backward(input, shift)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        grad_output, _ = grad_outputs
+        input, shift = ctx.saved_tensors
+        return ShiftGELU.__backward(grad_output, input, shift)
+
+    @staticmethod
+    def __forward(input: torch.Tensor, bias: torch.Tensor):
+        y_size, x_size = input.shape
+        output = torch.empty_like(input)
+        shift = torch.empty_like(input)
+
+        def grid(meta):
+            return (y_size * triton.cdiv(x_size, meta["x_block_size"]),)
+
+        kernel.ShiftGELU.forward[grid](output, shift, input, y_size, x_size, bias, util.dtype(input.dtype))
+
+        return output, shift
+
+    @staticmethod
+    def __backward(grad_output: torch.Tensor, input: torch.Tensor, shift: torch.Tensor):
+        y_size, x_size = input.shape
+        grad_input = torch.empty_like(input)
+
+        def grid(meta):
+            return (y_size * triton.cdiv(x_size, meta["x_block_size"]),)
+
+        kernel.ShiftGELU.backward[grid](grad_input, grad_output, shift, y_size, x_size, util.dtype(input.dtype))
+
+        return grad_input, torch.sum(grad_input, 0)


### PR DESCRIPTION
## 🙏 Describe the pull request

ShiftGELU is implemented.

## 💬 Additional context

The performance is enhanced 22% when tensor size is [2048, 16, 8192].

![shift-gelu](https://github.com/kakaobrain/trident/assets/7459074/f463ee23-633b-49cf-b681-347672ee7b1b)

```text
shift gelu forward:
     x_size     torch   trident
0     512.0  0.182121  0.134773
1    1024.0  0.337591  0.259952
2    1536.0  0.500334  0.385737
3    2048.0  0.659087  0.509330
4    2560.0  0.820202  0.636454
5    3072.0  0.983422  0.763442
6    3584.0  1.144667  0.888434
7    4096.0  1.304451  1.016340
8    4608.0  1.466277  1.140316
9    5120.0  1.629874  1.268613
10   5632.0  1.789245  1.391010
11   6144.0  1.949569  1.513940
12   6656.0  2.110991  1.641427
13   7168.0  2.273023  1.766664
14   7680.0  2.433502  1.887291
15   8192.0  2.595349  2.018630
16   8704.0  2.756817  2.144249
17   9216.0  2.917249  2.267828
18   9728.0  3.078329  2.392122
19  10240.0  3.239432  2.514512
```

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.