### PR TITLE
Fix overflow in InstanceNorm, LayerNorm and RMSNorm

### DIFF
--- a/trident/kernel/instance_norm.py
+++ b/trident/kernel/instance_norm.py
@@ -67,7 +67,7 @@ class InstanceNorm:
                 block_shape=(1,),
                 order=(0,),
             )
-            mean = (tl.sum(input, 1) / x_size).to(dtype)
+            mean = (tl.sum(input / x_size, 1)).to(dtype)
             tl.store(mean_block_ptr, mean)
         else:
             running_mean_block_ptr = tl.make_block_ptr(
@@ -92,7 +92,7 @@ class InstanceNorm:
                 block_shape=(1,),
                 order=(0,),
             )
-            var = (tl.sum(centered_mean * centered_mean, 1) / x_size).to(dtype)
+            var = (tl.sum(centered_mean * centered_mean / x_size, 1)).to(dtype)
             tl.store(var_block_ptr, var)
         else:
             running_var_block_ptr = tl.make_block_ptr(

--- a/trident/kernel/rms_norm.py
+++ b/trident/kernel/rms_norm.py
@@ -35,6 +35,7 @@ class RMSNorm:
         x_block_size: tl.constexpr,
     ):
         y_offset = tl.program_id(0)
+
         output_block_ptr = tl.make_block_ptr(
             output_ptr,
             shape=(y_size, x_size),
@@ -70,7 +71,7 @@ class RMSNorm:
 
         input = tl.load(input_block_ptr, boundary_check=(1,))
         partial_input = tl.where(tl.arange(0, x_block_size) < partial_size, input, 0)
-        rms = tl.math.sqrt(tl.sum(partial_input * partial_input, 1) / partial_size)
+        rms = tl.math.sqrt(tl.sum(partial_input * partial_input / partial_size, 1))
         norm = input / (rms + eps)
         weight = tl.load(weight_block_ptr, boundary_check=(0,))
         output = norm * weight
@@ -109,6 +110,7 @@ class RMSNorm:
         x_block_size: tl.constexpr,
     ):
         y_offset = tl.program_id(0)
+
         grad_input_block_ptr = tl.make_block_ptr(
             grad_input_ptr,
             shape=(y_size, x_size),


### PR DESCRIPTION
## 🙏 Describe the pull request

The calculation can cause overflow in InstanceNorm, LayerNorm and RMSNorm.

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.