### PR TITLE
Fix a bug in InstanceNorm not using input status

### DIFF
--- a/tests/test_instance_norm.py
+++ b/tests/test_instance_norm.py
@@ -19,7 +19,10 @@ import trident
 from tests import util
 
 
-@pytest.mark.parametrize("num_batches, y_size, x_size, use_input_stats", [(2, 8, 1024, True), (3, 5, 2000, False)])
+@pytest.mark.parametrize(
+    "num_batches, y_size, x_size, use_input_stats",
+    [(2, 8, 1024, True), (2, 2, 2, True), (3, 5, 2000, False)],
+)
 def test_forward(num_batches, y_size, x_size, use_input_stats, device):
     input = torch.randn(num_batches, y_size, x_size, device=device)
 

--- a/trident/kernel/instance_norm.py
+++ b/trident/kernel/instance_norm.py
@@ -143,6 +143,7 @@ class InstanceNorm:
         running_var_ptr: tl.tensor,
         num_batches: tl.int32,
         y_size: tl.int32,
+        x_size: tl.int32,
         momentum: tl.constexpr,
         batch_block_size: tl.constexpr,
     ):
@@ -188,7 +189,7 @@ class InstanceNorm:
         running_mean = tl.load(running_mean_block_ptr, boundary_check=(0,))
         running_mean = mean * momentum + running_mean * (1 - momentum)
         running_var = tl.load(running_var_block_ptr, boundary_check=(0,))
-        running_var = var * momentum + running_var * (1 - momentum)
+        running_var = var * (x_size / (x_size - 1)) * momentum + running_var * (1 - momentum)
         tl.store(running_mean_block_ptr, running_mean, boundary_check=(0,))
         tl.store(running_var_block_ptr, running_var, boundary_check=(0,))
 

--- a/trident/operation/instance_norm.py
+++ b/trident/operation/instance_norm.py
@@ -96,7 +96,15 @@ class InstanceNorm(torch.autograd.Function):
 
             util.push_trace("kernel.InstanceNorm.forward_running_mean_running_var")
             kernel.InstanceNorm.forward_running_mean_running_var[grid](
-                mean, var, running_mean, running_var, num_batches, y_size, momentum, triton.next_power_of_2(num_batches)
+                mean,
+                var,
+                running_mean,
+                running_var,
+                num_batches,
+                y_size,
+                x_size,
+                momentum,
+                triton.next_power_of_2(num_batches),
             )
             util.pop_trace()
 


### PR DESCRIPTION
## 🙏 Describe the pull request

* running_var 구할때는 correction 설정해서 구해야하는 것 같습니다. (분모 N이 아니라 N-1 이용.)
* N이 큰 값일때는 티가 안나지만 N이 작으면 테스트 실패합니다.

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.