### PR TITLE
Support bfloat16 in Linear and Attention

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -62,9 +62,6 @@ def test_backward(num_batches, num_heads, y_size, x_size, is_causal, device):
     "num_batches, num_heads, y_size, x_size, is_causal", [(1, 1, 1, 16, True), (1, 1, 1, 16, False)]
 )
 def test_attention(num_batches, num_heads, y_size, x_size, is_causal, device, dtype):
-    if dtype is torch.bfloat16:
-        pytest.skip("Triton has a bug.")
-
     factory_kwargs = {"device": device, "dtype": dtype}
     query = torch.rand(num_batches, num_heads, y_size, x_size, **factory_kwargs, requires_grad=True)
     key = torch.randn_like(query, requires_grad=True)

--- a/tests/test_geglu.py
+++ b/tests/test_geglu.py
@@ -86,9 +86,6 @@ def test_backward(num_batches, m_size, n_size, k_size, device):
 
 @pytest.mark.parametrize("num_batches, m_size, n_size, k_size", [(1, 16, 16, 16)])
 def test_geglu(num_batches, m_size, n_size, k_size, device, dtype):
-    if dtype is torch.bfloat16:
-        pytest.skip("Triton has a bug.")
-
     factory_kwargs = {"device": device, "dtype": dtype}
     x_size = n_size // 2
     input = torch.randn(num_batches, m_size, k_size, **factory_kwargs, requires_grad=True)

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -84,9 +84,6 @@ def test_backward(num_batches, m_size, n_size, k_size, device):
 
 @pytest.mark.parametrize("m_size, n_size, k_size", [(32, 32, 32)])
 def test_linear(m_size, n_size, k_size, device, dtype):
-    if dtype is torch.bfloat16:
-        pytest.skip("Triton has a bug.")
-
     factory_kwargs = {"device": device, "dtype": dtype}
     input = torch.randn(m_size, k_size, **factory_kwargs, requires_grad=True)
     weight = torch.randn(n_size, k_size, **factory_kwargs, requires_grad=True)

--- a/trident/language/linear.py
+++ b/trident/language/linear.py
@@ -15,6 +15,8 @@
 import triton
 import triton.language as tl
 
+from trident import language
+
 
 class Linear:
     @staticmethod
@@ -70,8 +72,7 @@ class Linear:
             else:
                 weight = tl.load(weight_block_ptr, boundary_check=(0, 1), padding_option="zero")
 
-            output += tl.dot(input, weight, allow_tf32=use_accelerator, out_dtype=dtype)
-
+            output += language.dot(input, weight, use_accelerator, dtype)
             input_block_ptr = tl.advance(input_block_ptr, (0, k_block_size))
             weight_block_ptr = tl.advance(weight_block_ptr, (k_block_size, 0))
 
@@ -88,6 +89,7 @@ class Linear:
                 bias = tl.load(bias_block_ptr)
             else:
                 bias = tl.load(bias_block_ptr, boundary_check=(0,), padding_option="zero")
+
             output += bias
 
         return output
@@ -142,8 +144,7 @@ class Linear:
             else:
                 weight = tl.load(weight_block_ptr, boundary_check=(0, 1), padding_option="zero")
 
-            grad_input += tl.dot(grad_output, weight, allow_tf32=use_accelerator, out_dtype=dtype)
-
+            grad_input += language.dot(grad_output, weight, use_accelerator, dtype)
             grad_output_block_ptr = tl.advance(grad_output_block_ptr, (0, n_block_size))
             weight_block_ptr = tl.advance(weight_block_ptr, (n_block_size, 0))
 
@@ -199,8 +200,7 @@ class Linear:
             else:
                 input = tl.load(input_block_ptr, boundary_check=(0, 1), padding_option="zero")
 
-            grad_weight += tl.dot(grad_output, input, allow_tf32=use_accelerator, out_dtype=dtype)
-
+            grad_weight += language.dot(grad_output, input, use_accelerator, dtype)
             grad_output_block_ptr = tl.advance(grad_output_block_ptr, (0, m_block_size))
             input_block_ptr = tl.advance(input_block_ptr, (m_block_size, 0))
 

--- a/trident/language/standard.py
+++ b/trident/language/standard.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import math
-from .combine import *
-from .constant import *
-from .linear import *
-from .mean import *
-from .standard import *
-from .sum import *
-from .var import *
-from .var_mean import *
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def dot(input: tl.tensor, other: tl.tensor, use_accelerator: tl.constexpr, dtype: tl.constexpr):
+    if dtype is tl.bfloat16:
+        return tl.dot(input, other, allow_tf32=use_accelerator, out_dtype=tl.float16).to(dtype)
+    else:
+        return tl.dot(input, other, allow_tf32=use_accelerator, out_dtype=dtype)


### PR DESCRIPTION
## 🙏 Describe the pull request

`tl.dot`은 출력으로 `bfloat16`을 지원하지 않습니다. 그러므로 `bfloat16`인 경우에 `float16` 결과를 출력하고 `bfloat16`으로 변환 합니다.

## ✅ Checklist

- [x] Code follows the project's coding conventions and style.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated, if necessary.